### PR TITLE
Fix verbosity command line argument

### DIFF
--- a/irohad/main/irohad.cpp
+++ b/irohad/main/irohad.cpp
@@ -115,6 +115,14 @@ int main(int argc, char *argv[]) {
   logger::LoggerManagerTreePtr log_manager;
   logger::LoggerPtr log;
 
+  // If the global log level override was set in the command line arguments,
+  // create a logger manager with the given log level for all subsystems:
+  if (FLAGS_verbosity != kLogSettingsFromConfigFile) {
+    logger::LoggerConfig cfg;
+    cfg.log_level = config_members::LogLevels.at(FLAGS_verbosity);
+    log_manager = std::make_shared<logger::LoggerManagerTree>(std::move(cfg));
+    log = log_manager->getChild("Init")->getLogger();
+  }
 
   // Check if validators are registered.
   if (not config_validator_registered


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Accidently these lines got removed.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

`-verbosity` argument works again

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

<!-- Explain what other alternates were considered and why the proposed version was selected -->
