### PR TITLE
CommandServiceImpl: fix observer lifetime problem

### DIFF
--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -36,7 +36,8 @@ namespace iroha {
           log_(std::move(log)) {
       // Notifier for all clients
       status_subscription_ = status_bus_->statuses().subscribe(
-          // TODO mboldyrev IR-426 capture this, wait termination in destructor
+          // TODO mboldyrev IR-426 research approaches to the problem of member
+          // observer lifetime.
           [cache = cache_](auto response) {
             // find response for this tx in cache; if status of received
             // response isn't "greater" than cached one, dismiss received one

--- a/irohad/torii/impl/command_service_impl.cpp
+++ b/irohad/torii/impl/command_service_impl.cpp
@@ -35,19 +35,20 @@ namespace iroha {
           tx_presence_cache_(std::move(tx_presence_cache)),
           log_(std::move(log)) {
       // Notifier for all clients
-      status_subscription_ =
-          status_bus_->statuses().subscribe([this](auto response) {
+      status_subscription_ = status_bus_->statuses().subscribe(
+          // TODO mboldyrev IR-426 capture this, wait termination in destructor
+          [cache = cache_](auto response) {
             // find response for this tx in cache; if status of received
             // response isn't "greater" than cached one, dismiss received one
             auto tx_hash = response->transactionHash();
-            auto cached_tx_state = cache_->findItem(tx_hash);
+            auto cached_tx_state = cache->findItem(tx_hash);
             if (cached_tx_state
                 and response->comparePriorities(**cached_tx_state)
                     != shared_model::interface::TransactionResponse::
                            PrioritiesComparisonResult::kGreater) {
               return;
             }
-            cache_->addItem(tx_hash, response);
+            cache->addItem(tx_hash, response);
           });
     }
 


### PR DESCRIPTION
<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

This is a quite dirty fix of the issue discovered in failing `command_service_replay_test`. The problem is that calling `unsubscribe()` on a subscription from `rxcpp::subjects::synchronize<T, rxcpp::observe_on_one_worker>` does not block until a currently running subscribed observer finishes. This lead to `CommandServiceImpl` destruction while there was still running an observer on statuses that was using  `CommandServiceImpl::cache_` member, which got invalidated.

There is a task to find a better way to handle this type of problems: [IR-426](https://jira.hyperledger.org/browse/IR-426).

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Fix.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

Need to capture everything needed for a subscriber by value.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

`command_service_replay_test`

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

Wait till the task finishes. Calling `unsubscribe()` allows it if we have a dedicated thread for our subscriber, but not when we reuse one.

<!-- Explain what other alternates were considered and why the proposed version was selected -->
