### PR TITLE
Ordering: batches propagation for (reject, commit) case

### DIFF
--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -158,9 +158,9 @@ namespace iroha {
          * irohad/ordering/impl/on_demand_connection_manager.cpp
          *
          *    0 1 2         0 1 2         0 1 2         0 1 2
-         *  0 o x v 0     0 o . .       0 o x .       0 o . .
-         *  1 . . . 1     1 x v .       1 v . .       1 x . .
-         *  2 . . . 2     2 . . .       2 . . .       2 v . .
+         *  0 o x v       0 o . .       0 o x .       0 o . .
+         *  1 . . .       1 x v .       1 v . .       1 x . .
+         *  2 . . .       2 . . .       2 . . .       2 v . .
          * RejectReject  CommitReject  RejectCommit  CommitCommit
          *
          * o - current round, x - next round, v - target round

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -157,14 +157,17 @@ namespace iroha {
          * See detailed description in
          * irohad/ordering/impl/on_demand_connection_manager.cpp
          *
-         *   0 1 2
-         * 0 o x v
-         * 1 v v .
-         * 2 v . .
+         *    0 1 2         0 1 2         0 1 2         0 1 2
+         *  0 o x v 0     0 o . .       0 o x .       0 o . .
+         *  1 . . . 1     1 x v .       1 v . .       1 x . .
+         *  2 . . . 2     2 . . .       2 . . .       2 v . .
+         * RejectReject  CommitReject  RejectCommit  CommitCommit
+         *
+         * o - current round, x - next round, v - target round
          *
          * v, round 0,2 - kRejectRejectConsumer
-         * v, round 1,1 - kRejectCommitConsumer
-         * v, round 1,0 - kCommitRejectConsumer
+         * v, round 1,1 - kCommitRejectConsumer
+         * v, round 1,0 - kRejectCommitConsumer
          * v, round 2,0 - kCommitCommitConsumer
          * o, round 0,0 - kIssuer
          */

--- a/irohad/main/impl/on_demand_ordering_init.cpp
+++ b/irohad/main/impl/on_demand_ordering_init.cpp
@@ -159,21 +159,24 @@ namespace iroha {
          *
          *   0 1 2
          * 0 o x v
-         * 1 x v .
+         * 1 v v .
          * 2 v . .
          *
-         * v, round 0 - kCurrentRoundRejectConsumer
-         * v, round 1 - kNextRoundRejectConsumer
-         * v, round 2 - kNextRoundCommitConsumer
-         * o, round 0 - kIssuer
+         * v, round 0,2 - kRejectRejectConsumer
+         * v, round 1,1 - kRejectCommitConsumer
+         * v, round 1,0 - kCommitRejectConsumer
+         * v, round 2,0 - kCommitCommitConsumer
+         * o, round 0,0 - kIssuer
          */
-        peers.peers.at(OnDemandConnectionManager::kCurrentRoundRejectConsumer) =
+        peers.peers.at(OnDemandConnectionManager::kRejectRejectConsumer) =
             getOsPeer(kCurrentRound,
                       ordering::currentRejectRoundConsumer(
                           current_round.reject_round));
-        peers.peers.at(OnDemandConnectionManager::kNextRoundRejectConsumer) =
+        peers.peers.at(OnDemandConnectionManager::kRejectCommitConsumer) =
+            getOsPeer(kNextRound, ordering::kNextCommitRoundConsumer);
+        peers.peers.at(OnDemandConnectionManager::kCommitRejectConsumer) =
             getOsPeer(kNextRound, ordering::kNextRejectRoundConsumer);
-        peers.peers.at(OnDemandConnectionManager::kNextRoundCommitConsumer) =
+        peers.peers.at(OnDemandConnectionManager::kCommitCommitConsumer) =
             getOsPeer(kRoundAfterNext, ordering::kNextCommitRoundConsumer);
         peers.peers.at(OnDemandConnectionManager::kIssuer) =
             getOsPeer(kCurrentRound, current_round.reject_round);

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -48,10 +48,11 @@ void OnDemandConnectionManager::onBatches(CollectionType batches) {
    * following two rounds. This can be visualised as a diagram, where: o -
    * current round, x - next round, v - target round
    *
-   *   0 1 2
-   * 0 o x v
-   * 1 v v .
-   * 2 v . .
+   *    0 1 2         0 1 2         0 1 2         0 1 2
+   *  0 o x v 0     0 o . .       0 o x .       0 o . .
+   *  1 . . . 1     1 x v .       1 v . .       1 x . .
+   *  2 . . . 2     2 . . .       2 . . .       2 v . .
+   * RejectReject  CommitReject  RejectCommit  CommitCommit
    */
 
   connections_.peers[kRejectRejectConsumer]->onBatches(batches);

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -49,9 +49,9 @@ void OnDemandConnectionManager::onBatches(CollectionType batches) {
    * current round, x - next round, v - target round
    *
    *    0 1 2         0 1 2         0 1 2         0 1 2
-   *  0 o x v 0     0 o . .       0 o x .       0 o . .
-   *  1 . . . 1     1 x v .       1 v . .       1 x . .
-   *  2 . . . 2     2 . . .       2 . . .       2 v . .
+   *  0 o x v       0 o . .       0 o x .       0 o . .
+   *  1 . . .       1 x v .       1 v . .       1 x . .
+   *  2 . . .       2 . . .       2 . . .       2 v . .
    * RejectReject  CommitReject  RejectCommit  CommitCommit
    */
 

--- a/irohad/ordering/impl/on_demand_connection_manager.cpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.cpp
@@ -44,20 +44,20 @@ void OnDemandConnectionManager::onBatches(CollectionType batches) {
   std::shared_lock<std::shared_timed_mutex> lock(mutex_);
   /*
    * Transactions are always sent to the round after the next round (+2)
-   * There are 3 possibilities - next reject in the current round, first reject
-   * in the next round, and first commit in the round after the next round
-   * This can be visualised as a diagram, where:
-   * o - current round, x - next round, v - target round
+   * There are 4 possibilities - all combinations of commits and rejects in the
+   * following two rounds. This can be visualised as a diagram, where: o -
+   * current round, x - next round, v - target round
    *
    *   0 1 2
    * 0 o x v
-   * 1 x v .
+   * 1 v v .
    * 2 v . .
    */
 
-  connections_.peers[kCurrentRoundRejectConsumer]->onBatches(batches);
-  connections_.peers[kNextRoundRejectConsumer]->onBatches(batches);
-  connections_.peers[kNextRoundCommitConsumer]->onBatches(batches);
+  connections_.peers[kRejectRejectConsumer]->onBatches(batches);
+  connections_.peers[kRejectCommitConsumer]->onBatches(batches);
+  connections_.peers[kCommitRejectConsumer]->onBatches(batches);
+  connections_.peers[kCommitCommitConsumer]->onBatches(batches);
 }
 
 boost::optional<std::shared_ptr<const OnDemandConnectionManager::ProposalType>>

--- a/irohad/ordering/impl/on_demand_connection_manager.hpp
+++ b/irohad/ordering/impl/on_demand_connection_manager.hpp
@@ -29,9 +29,10 @@ namespace iroha {
        * Proposal is requested from the current ordering service: issuer
        */
       enum PeerType {
-        kCurrentRoundRejectConsumer = 0,
-        kNextRoundRejectConsumer,
-        kNextRoundCommitConsumer,
+        kRejectRejectConsumer = 0,
+        kRejectCommitConsumer,
+        kCommitRejectConsumer,
+        kCommitCommitConsumer,
         kIssuer,
         kCount
       };

--- a/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
+++ b/test/module/irohad/ordering/on_demand_connection_manager_test.cpp
@@ -84,9 +84,10 @@ TEST_F(OnDemandConnectionManagerTest, onBatches) {
     EXPECT_CALL(*connections[type], onBatches(collection)).Times(1);
   };
 
-  set_expect(OnDemandConnectionManager::kCurrentRoundRejectConsumer);
-  set_expect(OnDemandConnectionManager::kNextRoundRejectConsumer);
-  set_expect(OnDemandConnectionManager::kNextRoundCommitConsumer);
+  set_expect(OnDemandConnectionManager::kRejectRejectConsumer);
+  set_expect(OnDemandConnectionManager::kRejectCommitConsumer);
+  set_expect(OnDemandConnectionManager::kCommitRejectConsumer);
+  set_expect(OnDemandConnectionManager::kCommitCommitConsumer);
 
   manager->onBatches(collection);
 }


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

<!-- You will not see HTML commented line in Pull Request body -->
<!-- Optional sections may be omitted. Just remove them or write None -->

<!-- ### Requirements -->
<!-- * Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion. -->
<!-- * All new code must have code coverage above 70% (https://docs.codecov.io/docs/about-code-coverage). -->
<!-- * CircleCI builds must be passed. -->
<!-- * Critical and blocker issues reported by Sorabot must be fixed. -->
<!-- * Branch must be rebased onto base branch (https://soramitsu.atlassian.net/wiki/spaces/IS/pages/11173889/Rebase+and+merge+guide). -->


### Description of the Change

Recently @luckychess discovered a round transition case not handled by our ordering service - when there is a reject followed by a commit. This change brings this transition equal to others.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Correct batches propagation for (reject, commit) case.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 

More network communications.

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests *[optional]*

<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->

### Alternate Designs *[optional]*

Define a single batches receiver based on current state (using linear scheme without commit,reject pair).

<!-- Explain what other alternates were considered and why the proposed version was selected -->
