### PR TITLE
Ordering Service max proposal size

### DIFF
--- a/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.cpp
@@ -116,8 +116,9 @@ getTransactions(size_t requested_tx_amount,
   std::vector<std::shared_ptr<shared_model::interface::Transaction>> collection;
 
   auto it = batch_collection.begin();
-  for (;
-       it != batch_collection.end() and collection.size() < requested_tx_amount;
+  for (; it != batch_collection.end()
+       and collection.size() + boost::size((*it)->transactions())
+           <= requested_tx_amount;
        ++it) {
     collection.insert(std::end(collection),
                       std::begin((*it)->transactions()),

--- a/test/integration/pipeline/batch_pipeline_test.cpp
+++ b/test/integration/pipeline/batch_pipeline_test.cpp
@@ -200,7 +200,7 @@ TEST_P(BatchPipelineTest, ValidBatch) {
       {signedTx(batch_transactions[0], kFirstUserKeypair),
        signedTx(batch_transactions[1], kSecondUserKeypair)});
 
-  integration_framework::IntegrationTestFramework(1)
+  integration_framework::IntegrationTestFramework(2)
       .setInitialState(kAdminKeypair)
       .sendTxAwait(createFirstUser())
       .sendTxAwait(createSecondUser())
@@ -243,7 +243,7 @@ TEST_F(BatchPipelineTest, InvalidAtomicBatch) {
       {signedTx(batch_transactions[0], kFirstUserKeypair),
        signedTx(batch_transactions[1], kSecondUserKeypair)});
 
-  integration_framework::IntegrationTestFramework(1)
+  integration_framework::IntegrationTestFramework(2)
       .setInitialState(kAdminKeypair)
       .sendTxAwait(createFirstUser())
       .sendTxAwait(createSecondUser())
@@ -305,7 +305,7 @@ TEST_F(BatchPipelineTest, InvalidOrderedBatch) {
        signedTx(batch_transactions[1], kSecondUserKeypair),
        signedTx(batch_transactions[2], kFirstUserKeypair)});
 
-  integration_framework::IntegrationTestFramework(1)
+  integration_framework::IntegrationTestFramework(3)
       .setInitialState(kAdminKeypair)
       .sendTxAwait(createFirstUser())
       .sendTxAwait(createSecondUser())


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Ordering Service would not produce proposal bigger than max_proposal_size.

The issue was:
max_proposal_size = 3
Two batches of two transactions arrive.
Both will be processed.
The resulting proposal will have 4 transactions inside.

### Benefits

Correct behavior.

### Usage Examples or Tests 

All the tests