### PR TITLE
OS: Transactions are not lost when received in reject rounds

### DIFF
--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -102,9 +102,9 @@ namespace iroha {
           proposal_map_;
 
       /**
-       * Collections of batches for current
+       * Collections of batches for current round
        */
-      detail::BatchSetType round_batches_;
+      detail::BatchSetType pending_batches_;
 
       /**
        * Read write mutex for public methods

--- a/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
+++ b/irohad/ordering/impl/on_demand_ordering_service_impl.hpp
@@ -102,9 +102,9 @@ namespace iroha {
           proposal_map_;
 
       /**
-       * Collections of batches for current and next rounds
+       * Collections of batches for current
        */
-      detail::BatchSetType current_round_batches_, next_round_batches_;
+      detail::BatchSetType round_batches_;
 
       /**
        * Read write mutex for public methods


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Fix behavior of Ordering Service.

Transactions received during reject rounds are not lost and queued for processing.


### Benefits

Iroha clients do not have to resend transactions in case of "reject-commit".


### Usage Examples or Tests 

on_demand_os_test

Thanks to @lebdron