### PR TITLE
Add Synchronization on Rejects

### DIFF
--- a/irohad/consensus/gate_object.hpp
+++ b/irohad/consensus/gate_object.hpp
@@ -27,26 +27,39 @@ namespace iroha {
       consensus::Round round;
     };
 
-    /// Network votes for another pair and round
-    struct VoteOther {
+    struct Synchronizable {
       shared_model::interface::types::PublicKeyCollectionType public_keys;
-      shared_model::interface::types::HashType hash;
       consensus::Round round;
+      Synchronizable(
+          shared_model::interface::types::PublicKeyCollectionType _public_keys,
+          consensus::Round _round)
+          : public_keys(std::move(_public_keys)), round(std::move(_round)) {}
+    };
+
+    /// Network votes for another pair and round
+    struct VoteOther : public Synchronizable {
+      shared_model::interface::types::HashType hash;
+      VoteOther(
+          shared_model::interface::types::PublicKeyCollectionType _public_keys,
+          consensus::Round _round,
+          shared_model::interface::types::HashType _hash)
+          : Synchronizable(std::move(_public_keys), std::move(_round)),
+            hash(std::move(_hash)) {}
     };
 
     /// Reject on proposal
-    struct ProposalReject {
-      consensus::Round round;
+    struct ProposalReject : public Synchronizable {
+      using Synchronizable::Synchronizable;
     };
 
     /// Reject on block
-    struct BlockReject {
-      consensus::Round round;
+    struct BlockReject : public Synchronizable {
+      using Synchronizable::Synchronizable;
     };
 
     /// Agreement on <None, None>
-    struct AgreementOnNone {
-      consensus::Round round;
+    struct AgreementOnNone : public Synchronizable {
+      using Synchronizable::Synchronizable;
     };
 
     using GateObject = boost::variant<PairValid,

--- a/irohad/synchronizer/impl/synchronizer_impl.cpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.cpp
@@ -36,47 +36,42 @@ namespace iroha {
 
     void SynchronizerImpl::processOutcome(consensus::GateObject object) {
       log_->info("processing consensus outcome");
+
       visit_in_place(
           object,
           [this](const consensus::PairValid &msg) { this->processNext(msg); },
           [this](const consensus::VoteOther &msg) {
-            this->processDifferent(msg);
+            this->processDifferent(msg,
+                                   false,
+                                   msg.round.block_round,
+                                   SynchronizationOutcomeType::kCommit);
           },
           [this](const consensus::ProposalReject &msg) {
-            // TODO: nickaleks IR-147 18.01.19 add peers
-            // list from GateObject when it has one
-            notifier_.get_subscriber().on_next(SynchronizationEvent{
-                rxcpp::observable<>::empty<
-                    std::shared_ptr<shared_model::interface::Block>>(),
-                SynchronizationOutcomeType::kReject,
-                msg.round});
+            this->processDifferent(msg,
+                                   true,
+                                   msg.round.block_round - 1,
+                                   SynchronizationOutcomeType::kReject);
           },
           [this](const consensus::BlockReject &msg) {
-            // TODO: nickaleks IR-147 18.01.19 add peers
-            // list from GateObject when it has one
-            notifier_.get_subscriber().on_next(SynchronizationEvent{
-                rxcpp::observable<>::empty<
-                    std::shared_ptr<shared_model::interface::Block>>(),
-                SynchronizationOutcomeType::kReject,
-                msg.round});
+            this->processDifferent(msg,
+                                   true,
+                                   msg.round.block_round - 1,
+                                   SynchronizationOutcomeType::kReject);
           },
           [this](const consensus::AgreementOnNone &msg) {
-            // TODO: nickaleks IR-147 18.01.19 add peers
-            // list from GateObject when it has one
-            notifier_.get_subscriber().on_next(SynchronizationEvent{
-                rxcpp::observable<>::empty<
-                    std::shared_ptr<shared_model::interface::Block>>(),
-                SynchronizationOutcomeType::kNothing,
-                msg.round});
+            this->processDifferent(msg,
+                                   true,
+                                   msg.round.block_round - 1,
+                                   SynchronizationOutcomeType::kNothing);
           });
     }
 
     boost::optional<SynchronizationEvent>
     SynchronizerImpl::downloadMissingBlocks(
-        const consensus::VoteOther &msg,
-        const shared_model::interface::types::HeightType height) {
-      auto expected_height = msg.round.block_round;
-
+        const consensus::Synchronizable &msg,
+        const shared_model::interface::types::HeightType top_block_height,
+        const shared_model::interface::types::HeightType expected_height,
+        const SynchronizationOutcomeType alternative_outcome) {
       // TODO mboldyrev 21.03.2019 IR-423 Allow consensus outcome update
       while (true) {
         // TODO andrei 17.10.18 IR-1763 Add delay strategy for loading blocks
@@ -88,7 +83,7 @@ namespace iroha {
 
           std::vector<std::shared_ptr<shared_model::interface::Block>> blocks;
           auto network_chain =
-              block_loader_->retrieveBlocks(height, public_key)
+              block_loader_->retrieveBlocks(top_block_height, public_key)
                   .tap([&blocks](std::shared_ptr<shared_model::interface::Block>
                                      block) {
                     blocks.push_back(std::move(block));
@@ -101,16 +96,18 @@ namespace iroha {
                 blocks, rxcpp::identity_immediate());
 
             auto ledger_state = mutable_factory_->commit(std::move(storage));
+            auto actual_height = blocks.back()->height();
+            bool higher_than_expected = actual_height > expected_height;
 
             if (ledger_state) {
               return SynchronizationEvent{
                   chain,
-                  SynchronizationOutcomeType::kCommit,
-                  blocks.back()->height() > expected_height
-                      // TODO 07.03.19 andrei: IR-387 Remove reject round
-                      ? consensus::Round{blocks.back()->height(), 0}
-                      : msg.round,
+                  higher_than_expected ? SynchronizationOutcomeType::kCommit
+                                       : alternative_outcome,
+                  higher_than_expected ? consensus::Round{actual_height, 0}
+                                       : msg.round,
                   std::move(*ledger_state)};
+              // TODO 07.03.19 andrei: IR-387 Remove reject round
             } else {
               return boost::none;
             }
@@ -167,26 +164,55 @@ namespace iroha {
       }
     }
 
-    void SynchronizerImpl::processDifferent(const consensus::VoteOther &msg) {
-      log_->info("at handleDifferent");
-
-      shared_model::interface::types::HeightType top_block_height{0};
+    boost::optional<shared_model::interface::types::HeightType>
+    SynchronizerImpl::getTopBlockHeight() const {
+      decltype(getTopBlockHeight()) top_block_height;
       if (auto block_query = block_query_factory_->createBlockQuery()) {
         top_block_height = (*block_query)->getTopBlockHeight();
       } else {
         log_->error(
             "Unable to create block query and retrieve top block height");
+      }
+      return top_block_height;
+    }
+
+    void SynchronizerImpl::processDifferent(
+        const consensus::Synchronizable &msg,
+        bool process_small_height_difference,
+        shared_model::interface::types::HeightType expected_height,
+        SynchronizationOutcomeType alternative_outcome) {
+      log_->info("at handleDifferent");
+
+      auto top_block_height = getTopBlockHeight();
+      if (not top_block_height) {
+        log_->error("Unable to continue without knowing top block height");
         return;
       }
 
-      if (top_block_height >= msg.round.block_round) {
+      int64_t height_diff = msg.round.block_round - *top_block_height;
+      if (height_diff < 0) {
         log_->info(
             "Storage is already in synchronized state. Top block height is {}",
-            top_block_height);
+            *top_block_height);
         return;
       }
 
-      auto result = downloadMissingBlocks(msg, top_block_height);
+      if (process_small_height_difference
+          and (0 == height_diff or 1 == height_diff)) {
+        notifier_.get_subscriber().on_next(
+            // TODO: nickaleks IR-147 18.01.19 add peers
+            // list from GateObject when it has one
+            SynchronizationEvent{
+                rxcpp::observable<>::empty<
+                    std::shared_ptr<shared_model::interface::Block>>(),
+                alternative_outcome,
+                msg.round,
+                nullptr /* this is going to be fixed in PR-2066 (IR-147) */});
+        return;
+      }
+
+      auto result = downloadMissingBlocks(
+          msg, *top_block_height, expected_height, alternative_outcome);
       if (result) {
         notifier_.get_subscriber().on_next(*result);
       }

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -43,15 +43,40 @@ namespace iroha {
        * Iterate through the peers which signed the commit_message, load and
        * apply the missing blocks
        * @param commit_message - the commit that triggered synchronization
-       * @param height - the top block height of a peer that needs to be
-       * synchronized
+       * @param top_block_height - the top block height of a peer that needs to
+       * be synchronized
+       * @param expected_height - the expected height of a top block after
+       * synchronization
+       * @param alternative_outcome - that kind of outcome will be propagated to
+       * subscribers when block store height after synchronization is less than
+       * expected
        */
       boost::optional<SynchronizationEvent> downloadMissingBlocks(
-          const consensus::VoteOther &msg,
-          const shared_model::interface::types::HeightType height);
+          const consensus::Synchronizable &msg,
+          const shared_model::interface::types::HeightType top_block_height,
+          const shared_model::interface::types::HeightType expected_height,
+          const SynchronizationOutcomeType alternative_outcome);
 
       void processNext(const consensus::PairValid &msg);
-      void processDifferent(const consensus::VoteOther &msg);
+
+      /**
+       * Performs synchronization on rejects
+       * @param msg - consensus gate message with a list of peers and a round
+       * @param process_small_height_difference - turn on or off small height
+       * difference handling (should be off for VoteOther type of messages)
+       * @param expected_height - an expected block store height after
+       * synchronization
+       * @param alternative_outcome - synchronization outcome when block store
+       * height is equal to expected height after synchronization
+       */
+      void processDifferent(
+          const consensus::Synchronizable &msg,
+          bool process_small_height_difference,
+          shared_model::interface::types::HeightType expected_height,
+          SynchronizationOutcomeType alternative_outcome);
+
+      boost::optional<shared_model::interface::types::HeightType>
+      getTopBlockHeight() const;
 
       boost::optional<std::unique_ptr<ametsuchi::MutableStorage>> getStorage();
 

--- a/irohad/synchronizer/impl/synchronizer_impl.hpp
+++ b/irohad/synchronizer/impl/synchronizer_impl.hpp
@@ -40,13 +40,11 @@ namespace iroha {
 
      private:
       /**
-       * Iterate through the peers which signed the commit_message, load and
+       * Iterate through the peers which signed the commit message, load and
        * apply the missing blocks
-       * @param commit_message - the commit that triggered synchronization
+       * @param msg - the commit message that triggered synchronization
        * @param top_block_height - the top block height of a peer that needs to
        * be synchronized
-       * @param expected_height - the expected height of a top block after
-       * synchronization
        * @param alternative_outcome - that kind of outcome will be propagated to
        * subscribers when block store height after synchronization is less than
        * expected
@@ -54,7 +52,6 @@ namespace iroha {
       boost::optional<SynchronizationEvent> downloadMissingBlocks(
           const consensus::Synchronizable &msg,
           const shared_model::interface::types::HeightType top_block_height,
-          const shared_model::interface::types::HeightType expected_height,
           const SynchronizationOutcomeType alternative_outcome);
 
       void processNext(const consensus::PairValid &msg);
@@ -62,18 +59,11 @@ namespace iroha {
       /**
        * Performs synchronization on rejects
        * @param msg - consensus gate message with a list of peers and a round
-       * @param process_small_height_difference - turn on or off small height
-       * difference handling (should be off for VoteOther type of messages)
-       * @param expected_height - an expected block store height after
-       * synchronization
        * @param alternative_outcome - synchronization outcome when block store
        * height is equal to expected height after synchronization
        */
-      void processDifferent(
-          const consensus::Synchronizable &msg,
-          bool process_small_height_difference,
-          shared_model::interface::types::HeightType expected_height,
-          SynchronizationOutcomeType alternative_outcome);
+      void processDifferent(const consensus::Synchronizable &msg,
+                            SynchronizationOutcomeType alternative_outcome);
 
       boost::optional<shared_model::interface::types::HeightType>
       getTopBlockHeight() const;


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Synchronizer now is able to download missing blocks even when reject is happened in consensus.

### Benefits

Performance of the network can be increased in some cases.

**Explanation**
Some peers at the network can be out of sync (the peer is in round 3, when the rest in 5).
Such a peer previously could sync even when a commit of 6th block happened.
Now the peer can sync early and be in a synchronized state when a commit of the 6th block is happening. 
Thus there is a chance to do consensus step faster.

### Possible Drawbacks 

Still some changes has to be introduced by #2066 to the structure of `SynchronizationEvent`.

### Usage Examples or Tests 

synchronizer_test