### PR TITLE
Fix server dependency in FakePeer; fix timer thread in YAC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,17 @@ if(WIN32)
     endif()
 endif()
 
+# workaround to prevent user-installed dependencies having higher precedence
+# than the ones downloaded with externalproject
+if(UNIX)
+  list(APPEND CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES
+    /usr/local/include
+    )
+  list(APPEND CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
+    /usr/local/include
+    )
+endif()
+
 if(COVERAGE)
   find_program(LCOV_PROGRAM lcov)
   if(NOT LCOV_PROGRAM)

--- a/irohad/consensus/yac/impl/yac.cpp
+++ b/irohad/consensus/yac/impl/yac.cpp
@@ -61,12 +61,12 @@ namespace iroha {
                std::shared_ptr<Timer> timer,
                ClusterOrdering order,
                logger::LoggerPtr log)
-          : vote_storage_(std::move(vote_storage)),
+          : log_(std::move(log)),
+            cluster_order_(order),
+            vote_storage_(std::move(vote_storage)),
             network_(std::move(network)),
             crypto_(std::move(crypto)),
-            timer_(std::move(timer)),
-            cluster_order_(order),
-            log_(std::move(log)) {}
+            timer_(std::move(timer)) {}
 
       // ------|Hash gate|------
 

--- a/irohad/consensus/yac/impl/yac_gate_impl.cpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.cpp
@@ -30,13 +30,13 @@ namespace iroha {
           std::shared_ptr<consensus::ConsensusResultCache>
               consensus_result_cache,
           logger::LoggerPtr log)
-          : hash_gate_(std::move(hash_gate)),
+          : log_(std::move(log)),
+            current_hash_(),
             orderer_(std::move(orderer)),
             hash_provider_(std::move(hash_provider)),
             block_creator_(std::move(block_creator)),
             consensus_result_cache_(std::move(consensus_result_cache)),
-            log_(std::move(log)),
-            current_hash_() {
+            hash_gate_(std::move(hash_gate)) {
         block_creator_->onBlock().subscribe(
             [this](const auto &event) { this->vote(event); });
       }

--- a/irohad/consensus/yac/impl/yac_gate_impl.hpp
+++ b/irohad/consensus/yac/impl/yac_gate_impl.hpp
@@ -53,19 +53,18 @@ namespace iroha {
         rxcpp::observable<GateObject> handleCommit(const CommitMessage &msg);
         rxcpp::observable<GateObject> handleReject(const RejectMessage &msg);
 
-        std::shared_ptr<HashGate> hash_gate_;
-        std::shared_ptr<YacPeerOrderer> orderer_;
-        std::shared_ptr<YacHashProvider> hash_provider_;
-        std::shared_ptr<simulator::BlockCreator> block_creator_;
-
-        std::shared_ptr<consensus::ConsensusResultCache>
-            consensus_result_cache_;
-
         logger::LoggerPtr log_;
 
         boost::optional<std::shared_ptr<shared_model::interface::Block>>
             current_block_;
         YacHash current_hash_;
+
+        std::shared_ptr<YacPeerOrderer> orderer_;
+        std::shared_ptr<YacHashProvider> hash_provider_;
+        std::shared_ptr<simulator::BlockCreator> block_creator_;
+        std::shared_ptr<consensus::ConsensusResultCache>
+            consensus_result_cache_;
+        std::shared_ptr<HashGate> hash_gate_;
       };
 
     }  // namespace yac

--- a/irohad/consensus/yac/yac.hpp
+++ b/irohad/consensus/yac/yac.hpp
@@ -90,19 +90,20 @@ namespace iroha {
                                     const std::vector<VoteMessage> &msg);
         void tryPropagateBack(const std::vector<VoteMessage> &state);
 
-        // ------|Fields|------
-        YacVoteStorage vote_storage_;
-        std::shared_ptr<YacNetwork> network_;
-        std::shared_ptr<YacCryptoProvider> crypto_;
-        std::shared_ptr<Timer> timer_;
-        rxcpp::subjects::subject<Answer> notifier_;
+        // ------|Logger|------
+        logger::LoggerPtr log_;
+
         std::mutex mutex_;
 
         // ------|One round|------
         ClusterOrdering cluster_order_;
 
-        // ------|Logger|------
-        logger::LoggerPtr log_;
+        // ------|Fields|------
+        rxcpp::subjects::subject<Answer> notifier_;
+        YacVoteStorage vote_storage_;
+        std::shared_ptr<YacNetwork> network_;
+        std::shared_ptr<YacCryptoProvider> crypto_;
+        std::shared_ptr<Timer> timer_;
       };
     }  // namespace yac
   }    // namespace consensus

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -74,8 +74,10 @@ namespace iroha {
       }
 
       auto YacInit::createTimer(std::chrono::milliseconds delay_milliseconds) {
-        return std::make_shared<TimerImpl>(delay_milliseconds,
-                                           rxcpp::observe_on_new_thread());
+        return std::make_shared<TimerImpl>(
+            delay_milliseconds,
+            // TODO 2019-04-10 andrei: IR-441 Share a thread between MST and YAC
+            rxcpp::observe_on_new_thread());
       }
 
       std::shared_ptr<YacGate> YacInit::initConsensusGate(

--- a/irohad/main/impl/consensus_init.cpp
+++ b/irohad/main/impl/consensus_init.cpp
@@ -74,20 +74,8 @@ namespace iroha {
       }
 
       auto YacInit::createTimer(std::chrono::milliseconds delay_milliseconds) {
-        return std::make_shared<TimerImpl>([delay_milliseconds, this] {
-          // static factory with a single thread
-          //
-          // observe_on_new_thread -- coordination which creates new thread with
-          // observe_on strategy -- all subsequent operations will be performed
-          // on this thread.
-          //
-          // scheduler owns a timeline that is exposed by the now() method.
-          // scheduler is also a factory for workers in that timeline.
-          //
-          // coordination is a factory for coordinators and has a scheduler.
-          return rxcpp::observable<>::timer(
-              std::chrono::milliseconds(delay_milliseconds), coordination_);
-        });
+        return std::make_shared<TimerImpl>(delay_milliseconds,
+                                           rxcpp::observe_on_new_thread());
       }
 
       std::shared_ptr<YacGate> YacInit::initConsensusGate(

--- a/irohad/main/impl/consensus_init.hpp
+++ b/irohad/main/impl/consensus_init.hpp
@@ -50,14 +50,6 @@ namespace iroha {
        private:
         auto createTimer(std::chrono::milliseconds delay_milliseconds);
 
-        // coordinator has a worker, and a factory for coordinated
-        // observables, subscribers and schedulable functions.
-        //
-        // A new thread scheduler is created
-        // by calling .create_coordinator().get_scheduler()
-        rxcpp::observe_on_one_worker coordination_{
-            rxcpp::observe_on_new_thread()};
-
         bool initialized_{false};
         std::shared_ptr<NetworkImpl> consensus_network_;
       };

--- a/test/framework/integration_framework/fake_peer/fake_peer.cpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.cpp
@@ -192,13 +192,15 @@ namespace integration_framework {
       return proposal_storage_;
     }
 
-    void FakePeer::run() {
+    std::unique_ptr<ServerRunner> FakePeer::run() {
       ensureInitialized();
       // start instance
       log_->info("starting listening server");
-      internal_server_ = std::make_unique<ServerRunner>(
-          getAddress(), log_manager_->getChild("InternalServer")->getLogger());
-      internal_server_->append(yac_transport_)
+      auto internal_server = std::make_unique<ServerRunner>(
+          getAddress(),
+          log_manager_->getChild("InternalServer")->getLogger(),
+          false);
+      internal_server->append(yac_transport_)
           .append(mst_transport_)
           .append(od_os_transport_)
           .append(synchronizer_transport_)
@@ -215,8 +217,9 @@ namespace integration_framework {
                         .c_str());
               },
               [this](const auto &err) {
-                log_->error("coul not start server!");
+                log_->error("could not start server!");
               });
+      return internal_server;
     }
 
     std::string FakePeer::getAddress() const {

--- a/test/framework/integration_framework/fake_peer/fake_peer.hpp
+++ b/test/framework/integration_framework/fake_peer/fake_peer.hpp
@@ -95,7 +95,7 @@ namespace integration_framework {
       ProposalStorage &getProposalStorage();
 
       /// Start the fake peer.
-      void run();
+      std::unique_ptr<ServerRunner> run();
 
       /// Get the address:port string of this peer.
       std::string getAddress() const;
@@ -243,8 +243,6 @@ namespace integration_framework {
       std::shared_ptr<OsNetworkNotifier> os_network_notifier_;
       std::shared_ptr<OgNetworkNotifier> og_network_notifier_;
       std::shared_ptr<OnDemandOsNetworkNotifier> od_os_network_notifier_;
-
-      std::unique_ptr<ServerRunner> internal_server_;
 
       std::shared_ptr<iroha::consensus::yac::YacCryptoProvider> yac_crypto_;
 

--- a/test/framework/integration_framework/integration_test_framework.cpp
+++ b/test/framework/integration_framework/integration_test_framework.cpp
@@ -172,6 +172,9 @@ namespace integration_framework {
     if (cleanup_on_exit_) {
       cleanup();
     }
+    for (auto &server : fake_peers_servers_) {
+      server->shutdown(std::chrono::system_clock::now());
+    }
     // the code below should be executed anyway in order to prevent app hang
     if (iroha_instance_ and iroha_instance_->getIrohaInstance()) {
       iroha_instance_->getIrohaInstance()->terminate(
@@ -348,10 +351,8 @@ namespace integration_framework {
           queue_cond.notify_all();
         });
 
-    iroha_instance_->getIrohaInstance()
-        ->getStorage()
-        ->on_commit()
-        .subscribe([this](auto committed_block) {
+    iroha_instance_->getIrohaInstance()->getStorage()->on_commit().subscribe(
+        [this](auto committed_block) {
           block_queue_.push(committed_block);
           log_->info("block commit");
           queue_cond.notify_all();
@@ -367,7 +368,7 @@ namespace integration_framework {
     if (fake_peers_.size() > 0) {
       log_->info("starting fake iroha peers");
       for (auto &fake_peer : fake_peers_) {
-        fake_peer->run();
+        fake_peers_servers_.push_back(fake_peer->run());
       }
     }
     // start instance

--- a/test/framework/integration_framework/integration_test_framework.hpp
+++ b/test/framework/integration_framework/integration_test_framework.hpp
@@ -52,7 +52,7 @@ namespace iroha {
       struct VoteMessage;
     }  // namespace yac
     struct Round;
-  }    // namespace consensus
+  }  // namespace consensus
   namespace network {
     class MstTransportGrpc;
     class OrderingServiceTransport;
@@ -499,10 +499,8 @@ namespace integration_framework {
     std::mutex queue_mu;
     std::condition_variable queue_cond;
     bool cleanup_on_exit_;
-    std::vector<std::pair<std::promise<std::shared_ptr<fake_peer::FakePeer>>,
-                          boost::optional<shared_model::crypto::Keypair>>>
-        fake_peers_promises_;
     std::vector<std::shared_ptr<fake_peer::FakePeer>> fake_peers_;
+    std::vector<std::unique_ptr<ServerRunner>> fake_peers_servers_;
   };
 
   template <typename Queue, typename ObjectType, typename WaitTime>

--- a/test/integration/consensus/consensus_sunny_day.cpp
+++ b/test/integration/consensus/consensus_sunny_day.cpp
@@ -107,14 +107,8 @@ class ConsensusSunnyDayTest : public ::testing::Test {
         },
         getTestLogger("YacNetwork"));
     crypto = std::make_shared<FixedCryptoProvider>(my_pub_key);
-    timer = std::make_shared<TimerImpl>([this] {
-      // static factory with a single thread
-      // see YacInit::createTimer in consensus_init.cpp
-      static rxcpp::observe_on_one_worker coordination(
-          rxcpp::observe_on_new_thread().create_coordinator().get_scheduler());
-      return rxcpp::observable<>::timer(std::chrono::milliseconds(delay),
-                                        coordination);
-    });
+    timer = std::make_shared<TimerImpl>(std::chrono::milliseconds(delay),
+                                        rxcpp::observe_on_new_thread());
     auto order = ClusterOrdering::create(default_peers);
     ASSERT_TRUE(order);
 


### PR DESCRIPTION
### Description of the Change
- Fix cyclic dependency in `Behavior` and `FakePeer` when it was possible for gRPC server and services to deadlock on destruction
- Fix thread management in Yac `TimerImpl`. Now a single thread is used for all invocations, and thread is destroyed together with `TimerImpl` class.

### Benefits
No random segfaults and locks in `fake_peer_example_test`

### Possible Drawbacks 
None

### Usage Examples or Tests
`fake_peer_example_test`, `yac_timer_test`