### PR TITLE
Bump Jinja version

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -8,7 +8,7 @@ docopt==0.6.2
 docutils==0.14
 idna==2.6
 imagesize==0.7.1
-Jinja2==2.10
+Jinja2==2.10.1
 livereload==2.5.1
 MarkupSafe==1.0
 pathtools==0.1.2


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

It was reported that Jinja 2.10 is vulnerable
![image](https://user-images.githubusercontent.com/36847043/55941983-14569800-5c4c-11e9-8744-ec38106fa323.png)

### Benefits

Up to date dependencies.

### Usage Examples or Tests 

```
pip install -r requirements.txt
cd docs/source
make permissions
make html
```
