### PR TITLE
Reorder validation rules in Postgres executor

### DIFF
--- a/irohad/ametsuchi/impl/postgres_command_executor.cpp
+++ b/irohad/ametsuchi/impl/postgres_command_executor.cpp
@@ -483,8 +483,8 @@ namespace iroha {
           )
           SELECT CASE
               WHEN EXISTS (SELECT * FROM insert_account_role) THEN 0
-              %s
               WHEN NOT EXISTS (SELECT * FROM get_domain_default_role) THEN 3
+              %s
               ELSE 1
               END AS result)";
 
@@ -636,9 +636,9 @@ namespace iroha {
                   RETURNING (1)
               )
               SELECT CASE WHEN EXISTS (SELECT * FROM inserted) THEN 0
-                  %s
                   WHEN NOT EXISTS
                       (SELECT * FROM account WHERE account_id=$2) THEN 3
+                  %s
                   ELSE 1 END AS result)";
 
     const std::string PostgresCommandExecutor::setQuorumBase = R"(
@@ -771,10 +771,10 @@ namespace iroha {
                )
           SELECT CASE
               WHEN EXISTS (SELECT * FROM insert_dest LIMIT 1) THEN 0
-              %s
               WHEN NOT EXISTS (SELECT * FROM has_dest_account LIMIT 1) THEN 4
               WHEN NOT EXISTS (SELECT * FROM has_src_account LIMIT 1) THEN 3
               WHEN NOT EXISTS (SELECT * FROM has_asset LIMIT 1) THEN 5
+              %s
               WHEN NOT EXISTS (SELECT value FROM new_src_value
                                WHERE value >= 0 LIMIT 1) THEN 6
               WHEN NOT EXISTS (SELECT value FROM new_dest_value

--- a/test/module/irohad/ametsuchi/postgres_executor_test.cpp
+++ b/test/module/irohad/ametsuchi/postgres_executor_test.cpp
@@ -74,6 +74,7 @@ namespace iroha {
                             bool do_validation = false,
                             const shared_model::interface::types::AccountIdType
                                 &creator = "id@domain") {
+        // TODO igor-egorov 15.04.2019 IR-446 Refactor postgres_executor_test
         executor->doValidation(not do_validation);
         executor->setCreatorAccountId(creator);
         return executor->operator()(std::forward<CommandType>(command));
@@ -1849,6 +1850,15 @@ namespace iroha {
      * @then account asset fails to be transferred
      */
     TEST_F(TransferAccountAssetTest, NoPerms) {
+      addAsset();
+      CHECK_SUCCESSFUL_RESULT(
+          execute(*mock_command_factory->constructAddAssetQuantity(
+                      asset_id, asset_amount_one_zero),
+                  true));
+      auto account_asset = sql_query->getAccountAsset(account_id, asset_id);
+      ASSERT_TRUE(account_asset);
+      ASSERT_EQ(asset_amount_one_zero, account_asset.get()->balance());
+
       auto cmd_result = execute(*mock_command_factory->constructTransferAsset(
           account_id, account2_id, asset_id, "desc", asset_amount_one_zero));
 


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

### Description of the Change

Before the change, TransferAsset to non-existing account might lead to misleading error message "account does not have a permission". (Formally that was correct - "non-existing account does not have permissions at all")

### Benefits

A correct error message will be produced: account does not exist or account does not have permission for each case correspondingly.

### Usage Examples or Tests 

all the tests
