### PR TITLE
Add option to load peers from a file on startup

### DIFF
--- a/irohad/ametsuchi/impl/storage_impl.hpp
+++ b/irohad/ametsuchi/impl/storage_impl.hpp
@@ -95,7 +95,11 @@ namespace iroha {
           const std::vector<std::shared_ptr<shared_model::interface::Block>>
               &blocks) override;
 
+      bool insertPeer(const shared_model::interface::Peer &peer) override;
+
       void reset() override;
+
+      void resetPeers() override;
 
       void dropStorage() override;
 
@@ -188,6 +192,7 @@ namespace iroha {
      protected:
       static const std::string &drop_;
       static const std::string &reset_;
+      static const std::string &reset_peers_;
       static const std::string &init_;
     };
   }  // namespace ametsuchi

--- a/irohad/ametsuchi/storage.hpp
+++ b/irohad/ametsuchi/storage.hpp
@@ -61,6 +61,13 @@ namespace iroha {
               &blocks) = 0;
 
       /**
+       * Inserts peer into WSV
+       * @param peer - peer to insert
+       * @return true if inserted
+       */
+      virtual bool insertPeer(const shared_model::interface::Peer &peer) = 0;
+
+      /**
        * method called when block is written to the storage
        * @return observable with the Block committed
        */
@@ -72,6 +79,11 @@ namespace iroha {
        * Remove all records from the tables and remove all the blocks
        */
       virtual void reset() = 0;
+
+      /**
+       * Removes all saved peers
+       */
+      virtual void resetPeers() = 0;
 
       /**
        * Remove all information from ledger

--- a/irohad/main/CMakeLists.txt
+++ b/irohad/main/CMakeLists.txt
@@ -21,6 +21,12 @@ target_link_libraries(raw_block_loader
     logger
     )
 
+add_library(peers_file_reader impl/peers_file_reader_impl.cpp)
+target_link_libraries(peers_file_reader
+    shared_model_interfaces
+    parser
+    )
+
 add_library(application
     application.cpp
     # TODO andrei 08.11.2018 IR-1851 Create separate targets for initialization
@@ -61,6 +67,7 @@ add_executable(irohad irohad.cpp)
 target_link_libraries(irohad
     application
     raw_block_loader
+    peers_file_reader
     gflags
     rapidjson
     keys_manager

--- a/irohad/main/application.hpp
+++ b/irohad/main/application.hpp
@@ -93,26 +93,29 @@ class Irohad {
    * transactions
    * @param stale_stream_max_rounds - maximum number of rounds between
    * consecutive status emissions
+   *
    * @param logger_manager - the logger manager to use
    * @param opt_mst_gossip_params - parameters for Gossip MST propagation
    * (optional). If not provided, disables mst processing support
    * TODO mboldyrev 03.11.2018 IR-1844 Refactor the constructor.
    */
-  Irohad(const std::string &block_store_dir,
-         const std::string &pg_conn,
-         const std::string &listen_ip,
-         size_t torii_port,
-         size_t internal_port,
-         size_t max_proposal_size,
-         std::chrono::milliseconds proposal_delay,
-         std::chrono::milliseconds vote_delay,
-         std::chrono::minutes mst_expiration_time,
-         const shared_model::crypto::Keypair &keypair,
-         std::chrono::milliseconds max_rounds_delay,
-         size_t stale_stream_max_rounds,
-         logger::LoggerManagerTreePtr logger_manager,
-         const boost::optional<iroha::GossipPropagationStrategyParams>
-             &opt_mst_gossip_params = boost::none);
+  Irohad(
+      const std::string &block_store_dir,
+      const std::string &pg_conn,
+      const std::string &listen_ip,
+      size_t torii_port,
+      size_t internal_port,
+      size_t max_proposal_size,
+      std::chrono::milliseconds proposal_delay,
+      std::chrono::milliseconds vote_delay,
+      std::chrono::minutes mst_expiration_time,
+      const shared_model::crypto::Keypair &keypair,
+      std::chrono::milliseconds max_rounds_delay,
+      size_t stale_stream_max_rounds,
+      std::vector<std::unique_ptr<shared_model::interface::Peer>> initial_peers,
+      logger::LoggerManagerTreePtr logger_manager,
+      const boost::optional<iroha::GossipPropagationStrategyParams>
+          &opt_mst_gossip_params = boost::none);
 
   /**
    * Initialization of whole objects in system
@@ -124,6 +127,8 @@ class Irohad {
    * @return true on success, false otherwise
    */
   bool restoreWsv();
+
+  bool updatePeers();
 
   /**
    * Drop wsv and block store
@@ -197,6 +202,7 @@ class Irohad {
   std::chrono::minutes mst_expiration_time_;
   std::chrono::milliseconds max_rounds_delay_;
   size_t stale_stream_max_rounds_;
+  std::vector<std::unique_ptr<shared_model::interface::Peer>> initial_peers_;
   boost::optional<iroha::GossipPropagationStrategyParams>
       opt_mst_gossip_params_;
 

--- a/irohad/main/impl/peers_file_reader_impl.cpp
+++ b/irohad/main/impl/peers_file_reader_impl.cpp
@@ -1,0 +1,60 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "peers_file_reader_impl.hpp"
+
+#include <fstream>
+
+#include "cryptography/public_key.hpp"
+#include "interfaces/common_objects/types.hpp"
+#include "parser/parser.hpp"
+
+using namespace iroha::main;
+
+boost::optional<std::string> PeersFileReaderImpl::openFile(
+    const std::string &name) {
+  std::ifstream file(name);
+  if (not file) {
+    return boost::none;
+  }
+
+  std::string str((std::istreambuf_iterator<char>(file)),
+                  std::istreambuf_iterator<char>());
+  return str;
+}
+
+boost::optional<std::vector<std::unique_ptr<shared_model::interface::Peer>>>
+PeersFileReaderImpl::readPeers(
+    const std::string &peers_data,
+    std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+        common_objects_factory) {
+  auto strings = parser::split(peers_data);
+  if (strings.size() % 2 != 0) {
+    return boost::none;
+  }
+
+  std::vector<std::unique_ptr<shared_model::interface::Peer>> peers{};
+
+  for (uint32_t i = 0; i < strings.size(); i += 2) {
+    shared_model::interface::types::AddressType address = strings.at(i);
+    shared_model::interface::types::PubkeyType key(
+        shared_model::interface::types::PubkeyType::fromHexString(
+            strings.at(i + 1)));
+    auto peer = common_objects_factory->createPeer(address, key);
+
+    if (auto e = boost::get<expected::Error<std::string>>(&peer)) {
+      return boost::none;
+    }
+
+    peers.emplace_back(std::move(
+        boost::get<
+            expected::Value<std::unique_ptr<shared_model::interface::Peer>>>(
+            &peer)
+            ->value));
+  }
+  return boost::make_optional<
+      std::vector<std::unique_ptr<shared_model::interface::Peer>>>(
+      std::move(peers));
+}

--- a/irohad/main/impl/peers_file_reader_impl.hpp
+++ b/irohad/main/impl/peers_file_reader_impl.hpp
@@ -1,0 +1,26 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PEERS_FILE_READER_IMPL_HPP
+#define IROHA_PEERS_FILE_READER_IMPL_HPP
+
+#include "main/peers_file_reader.hpp"
+
+namespace iroha {
+  namespace main {
+    class PeersFileReaderImpl : public PeersFileReader {
+     public:
+      boost::optional<std::string> openFile(const std::string &name) override;
+
+      boost::optional<
+          std::vector<std::unique_ptr<shared_model::interface::Peer>>>
+      readPeers(const std::string &peers_data,
+                std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+                    common_objects_factory) override;
+    };
+  }  // namespace main
+}  // namespace iroha
+
+#endif  // IROHA_PEERS_FILE_READER_IMPL_HPP

--- a/irohad/main/peers_file_reader.hpp
+++ b/irohad/main/peers_file_reader.hpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef IROHA_PEERS_FILE_READER_HPP
+#define IROHA_PEERS_FILE_READER_HPP
+
+#include <boost/optional.hpp>
+#include "interfaces/common_objects/common_objects_factory.hpp"
+#include "interfaces/common_objects/peer.hpp"
+
+namespace iroha {
+  namespace main {
+    /**
+     * Peers reader interface from a file
+     */
+    class PeersFileReader {
+     public:
+      /**
+       * Opens file with peers and returns its contents
+       * @param name - file name to open
+       * @return optional for a file contents or boost::none
+       */
+      virtual boost::optional<std::string> openFile(
+          const std::string &name) = 0;
+
+      /**
+       * Parses peers from a provided string
+       * @param peers_data - peers string to parse
+       * @param common_objects_factory - factory to create peers
+       * @return optional for collection of peers or boost::none
+       */
+      virtual boost::optional<
+          std::vector<std::unique_ptr<shared_model::interface::Peer>>>
+      readPeers(const std::string &peers_data,
+                std::shared_ptr<shared_model::interface::CommonObjectsFactory>
+                    common_objects_factory) = 0;
+    };
+  }  // namespace main
+}  // namespace iroha
+
+#endif  // IROHA_PEERS_FILE_READER_HPP

--- a/test/framework/integration_framework/iroha_instance.cpp
+++ b/test/framework/integration_framework/iroha_instance.cpp
@@ -78,6 +78,7 @@ namespace integration_framework {
 
   void IrohaInstance::initPipeline(
       const shared_model::crypto::Keypair &key_pair, size_t max_proposal_size) {
+    auto peers = std::vector<std::unique_ptr<shared_model::interface::Peer>>{};
     instance_ = std::make_shared<TestIrohad>(block_store_dir_,
                                              pg_conn_,
                                              listen_ip_,
@@ -90,6 +91,7 @@ namespace integration_framework {
                                              key_pair,
                                              max_rounds_delay_,
                                              stale_stream_max_rounds_,
+                                             std::move(peers),
                                              irohad_log_manager_,
                                              log_,
                                              opt_mst_gossip_params_);

--- a/test/framework/integration_framework/iroha_instance.hpp
+++ b/test/framework/integration_framework/iroha_instance.hpp
@@ -21,6 +21,7 @@
 namespace shared_model {
   namespace interface {
     class Block;
+    class Peer;
   }  // namespace interface
   namespace crypto {
     class Keypair;

--- a/test/framework/integration_framework/test_irohad.hpp
+++ b/test/framework/integration_framework/test_irohad.hpp
@@ -28,6 +28,8 @@ namespace integration_framework {
                const shared_model::crypto::Keypair &keypair,
                std::chrono::milliseconds max_rounds_delay,
                size_t stale_stream_max_rounds,
+               std::vector<std::unique_ptr<shared_model::interface::Peer>>
+                   initial_peers,
                logger::LoggerManagerTreePtr irohad_log_manager,
                logger::LoggerPtr log,
                const boost::optional<iroha::GossipPropagationStrategyParams>
@@ -44,6 +46,7 @@ namespace integration_framework {
                  keypair,
                  max_rounds_delay,
                  stale_stream_max_rounds,
+                 std::move(initial_peers),
                  std::move(irohad_log_manager),
                  opt_mst_gossip_params),
           log_(std::move(log)) {}

--- a/test/module/irohad/ametsuchi/mock_storage.hpp
+++ b/test/module/irohad/ametsuchi/mock_storage.hpp
@@ -45,7 +45,9 @@ namespace iroha {
       MOCK_METHOD1(insertBlocks,
                    bool(const std::vector<
                         std::shared_ptr<shared_model::interface::Block>> &));
+      MOCK_METHOD1(insertPeer, bool(const shared_model::interface::Peer &));
       MOCK_METHOD0(reset, void(void));
+      MOCK_METHOD0(resetPeers, void(void));
       MOCK_METHOD0(dropStorage, void(void));
       MOCK_METHOD0(freeConnections, void(void));
       MOCK_METHOD1(prepareBlock_, void(std::unique_ptr<TemporaryWsv> &));


### PR DESCRIPTION
### Description of the Change
Pull request adds command line option to load peers list from a file on startup.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
It could be useful in scenarios when many peers in a current network state are malicious.

### Possible Drawbacks 
- Usage of a potentially deprecated PostgresWsvCommand class
- Lack of tests for PeersFileReaderImpl (not sure should I add add them or not)

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->

### Usage Examples or Tests 
Create file `peers` with line `127.0.0.1:10001 bddd58404d1315e0eb27902c5d7c8eb0602c16238f005773df406bc191308929` (feel free to add more peers) and 
run irohad with option `--peers peers`
<!-- Point reviewers to the test, code example or documentation which shows usage example of this feature -->


